### PR TITLE
Feat: Migrate manifest to version 3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Github Unicorn",
 	"description": "Let's make git stylish again!",
 	"version": "0.1",
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"icons": {
 		"128": "assets/icon_no_background.png"
 	},

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 	"icons": {
 		"128": "assets/icon_no_background.png"
 	},
-	"browser_action": {
+	"action": {
 		"default_icon": "assets/icon_no_background.png",
 		"default_popup": "popup.html"
 	},
@@ -18,5 +18,8 @@
 		}
 	],
 	"permissions": ["activeTab", "storage", "management"],
-	"web_accessible_resources": ["themes.json"]
+	"web_accessible_resources": [{
+		"resources": ["themes.json"],
+		"matches": ["https://github.com/*"]
+	}]
 }

--- a/script.js
+++ b/script.js
@@ -2,7 +2,9 @@ button = document.querySelector("#select");
 button.addEventListener("click", selectTheme);
 button.addEventListener("mouseout", onMouseOut);
 button.addEventListener("mouseover", onMouseOver);
-
+if (typeof browser === "undefined") {
+    var browser = chrome;
+}
 function onMouseOut() {
 	chbg("1px solid #3f3d56");
 }
@@ -13,7 +15,7 @@ function onMouseOver() {
 (function () {
 	let today = new Date();
 	if (today.getMonth() == 11 && today.getDate() == 25)
-		document.getElementById('unicorn_logo').src = chrome.extension.getURL('assets/christmas_icon.svg');
+		document.getElementById('unicorn_logo').src = browser.runtime.getURL('assets/christmas_icon.svg');
 })();
 
 function dateToEpoch2(thedate) {

--- a/setTheme.js
+++ b/setTheme.js
@@ -1,9 +1,12 @@
+if (typeof browser === "undefined") {
+    var browser = chrome;
+}
 chrome.storage.sync.get(["currentTheme"], applyingTheme);
 
 function applyingTheme(currentTheme) {
 	let sTheme = {};
 
-	fetch(chrome.extension.getURL("./themes.json"))
+	fetch(browser.runtime.getURL("./themes.json"))
 		.then((resp) => resp.json())
 		.then(function (jsonData) {
 			if (jsonData[currentTheme.currentTheme] != undefined) {


### PR DESCRIPTION
Manifest version 2 will be deprecated in 2023 and totally disabled in 2024.
I made the changes in the manifest.json and replace old browser api with the new features.